### PR TITLE
Dev server (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,13 @@
 Server for synchronizing reminders on phone
 
 ## Environment
-Python 3.11
-Postgresql
+- Python 3.11
+- Postgresql
+
+## How to install
+1. Download repository and change directory to new folder with its name
+2. Setup PostgreSQL
+3. Copy config file from example `config.toml.example` and rename it to config.toml
+4. Put format connection string to database with your credentials and other parameters
+5. Run server using `python -m src`
+6. Check if application is working on http://localhost:8900

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1,0 +1,465 @@
+openapi: "3.0.2"
+info:
+  title: RemindMe API
+  version: "1.0"
+servers:
+  - url: http://localhost:9000/
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: UserToken
+
+  schemas:
+    Reminder:
+      properties:
+        properties:
+          id:
+            type: integer
+            description: event ID
+
+          title:
+            type: string
+            maxLength: 65
+            description: Even title
+
+          description:
+            type: string
+            maxLength: 240
+            description: Event description
+
+          color_code:
+            type: string
+            example: 33FF33
+            description: HEX representation of colors
+
+          created_at:
+            type: string
+            format: date-time
+            description: When event was created
+
+          last_edited_at:
+            type: string
+            format: date-time
+            description: When event was last edited, so other clients can update their events to latest version without conflicts
+
+          triggered_at:
+            type: string
+            format: date-time
+            description: When will the event be triggered first time as notification
+
+          is_active:
+            type: boolean
+            description: Is this reminder active
+            default: true
+
+          is_periodic:
+            type: boolean
+            description: Describes is event periodic or not
+            default: true
+
+          trigger_period:
+            type: integer
+            description: after how many days event should be triggered again
+
+paths:
+  /users/register:
+    post:
+      summary: Registers users account with provided credential
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  description: Desired login for new user account
+                  type: string
+                  pattern: "^[A-z0-9_]{8,}"
+                password:
+                  description: Desired password for new user account
+                  type: string
+                  pattern: "^[A-z0-9_+\-=]{8,}"
+      responses:
+        '200':
+          description: Indication of was user registered or not using provided credentials
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  registered:
+                    type: boolean
+                    default: true
+
+        '400':
+          description: Something is wrong with request body (either login or password not matching requirements)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    type: string
+                    description: Human-readable reason for registration denial
+
+        '409':
+          description: Already have user registered with provided login
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    type: string
+                    description: Human-readable reason for registration denial
+
+                  registered:
+                    type: boolean
+                    default: false
+                    description: Indicates that registration failed in this scenario
+
+  /users/login:
+    post:
+      summary: Provides user with access token if login and password that been provided are registered. Token must be used to access all other endpoints.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  description: User login
+                  type: string
+                password:
+                  description: Users password associated with provided login
+                  type: string
+
+      responses:
+        '200':
+          description: User successfully logged in
+          headers:
+            Set-Cookie:
+              schema:
+                description: Authorization cookie being set for other paths
+                type: string
+                example: UserToken=abswhe1111...; Path=/; HttpOnly
+
+        '400':
+          description: Something is wrong with request body (invalid format)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    type: string
+                    description: Human-readable reason for request denial
+
+        '401':
+          description: User did not provide correct password for corresponding login
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    description: Human-readable description of why login attempt was unsuccessful
+                    type: string
+
+        '404':
+          description: User not found with such login
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    description: Human-readable description of why login attempt was unsuccessful
+                    type: string
+
+  /users/logout:
+    post:
+      summary: Removes user token from cookies to log out of account
+      security:
+        - cookieAuth: [ ]
+
+      responses:
+        '200':
+          description: Cookie removed
+          headers:
+            Set-Cookie:
+              description: The AccessToken cookie will be removed
+              schema:
+                type: string
+                example: UserToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+        '401':
+          description: User is not logged into account
+
+  /reminders/:
+    get:
+      summary: Fetches all users events that are related to user
+      security:
+        - cookieAuth: [ ]
+
+      responses:
+        '200':
+          description: All events fetched successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Reminder"
+
+        '401':
+          description: User is not logged into account
+
+
+    post:
+      summary: Creates new event
+      security:
+        - cookieAuth: [ ]
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  minLength: 1
+                  maxLength: 65
+                  description: Event title
+
+                description:
+                  type: string
+                  maxLength: 240
+                  description: Event description
+
+                color_code:
+                  type: string
+                  example: 33FF33
+                  description: HEX representation of colors
+
+                triggered_at:
+                  type: string
+                  format: date-time
+                  description: When will the event be triggered first time as notification
+
+                is_periodic:
+                  type: boolean
+                  description: Describes is event periodic or not
+                  default: true
+
+                trigger_period:
+                  type: integer
+                  description: after how many days event should be triggered again (0 stands for not periodic events)
+
+      responses:
+        '200':
+          description: Event created
+
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  is_created:
+                    type: boolean
+                    default: true
+
+                  event_id:
+                    type: integer
+                    description: ID of new event
+
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    type: string
+                    description: Human-readable explanation of invalid request body
+
+        '401':
+          description: User is not logged into account
+
+  /reminders/{reminderId}:
+    get:
+      summary: Fetches specific event by provided ID
+      security:
+        - cookieAuth: [ ]
+
+      parameters:
+        - in: path
+          name: reminderId
+          schema:
+            type: integer
+          required: true
+          description: ID of specific event
+
+      responses:
+        '200':
+          description: Event fetched by it's ID
+
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Reminder"
+
+        '400':
+          description: Provided parameter in request is invalid
+
+        '401':
+          description: User is not logged into account
+
+        '404':
+          description: Event with specified ID was not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    type: string
+                    description: Human-readable reason for not finding event
+
+    delete:
+      summary: Removes event from being active
+      security:
+        - cookieAuth: [ ]
+
+      parameters:
+        - in: path
+          name: reminderId
+          schema:
+            type: integer
+          required: true
+          description: ID of specific event
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                event_id:
+                  type: integer
+                  description: ID of event to be deleted
+
+      responses:
+        '200':
+          description: Event has been successfully deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted_event_id:
+                    type: integer
+
+                  has_been_deactivated:
+                    type: boolean
+                    default: true
+
+        '400':
+          description: Provided parameter in request is invalid
+
+        '404':
+          description: Event has not been found in active list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    type: string
+                    description: Human-readable explanation of why event was not deleted
+
+    patch:
+      summary: Updates specified event fields with new data
+      security:
+        - cookieAuth: [ ]
+
+      parameters:
+        - in: path
+          name: reminderId
+          schema:
+            type: integer
+          required: true
+          description: ID of specific event
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                title:
+                  type: string
+                  minLength: 1
+                  maxLength: 65
+                  description: Event title
+
+                description:
+                  type: string
+                  maxLength: 240
+                  description: Event description
+
+                color_code:
+                  type: string
+                  example: 33FF33
+                  description: HEX representation of colors
+
+                triggered_at:
+                  type: string
+                  format: date-time
+                  description: When will the event be triggered first time as notification
+
+                is_periodic:
+                  type: boolean
+                  description: Describes is event periodic or not
+                  default: true
+
+                trigger_period:
+                  type: integer
+                  description: after how many days event should be triggered again
+
+      responses:
+        '200':
+          description: Successfully updated event
+
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  description: Names of updates fields on specified event
+
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reason:
+                    type: string
+                    description: Human-readable explanation of invalid request body
+
+        '401':
+          description: User is not logged into account

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,5 @@
+[RemindMe]
+host = "127.0.0.1"
+port = 8900
+debug = true
+engine_connection = "postgresql+asyncpg://RemindMeUser:example@localhost/remind_me"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ orjson~=3.10.7
 pytest~=8.3.3
 flake8~=7.1.1
 mypy~=1.11.2
+asyncpg~=0.30.0

--- a/src/DTO/reminder_DTO.py
+++ b/src/DTO/reminder_DTO.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from dataclasses import dataclass
+
+from src.models.reminder import Reminder
+
+
+@dataclass
+class ReminderDTO:
+    """
+    DTO for storing and converting Reminder object into JSON.
+    """
+
+    id: int
+    title: str
+    description: str
+    color_code: str
+    is_active: bool
+    is_periodic: bool
+    created_at: datetime
+    last_edited_at: datetime
+    triggered_at: datetime
+    trigger_period: int
+
+    @classmethod
+    def from_reminder(cls, reminder: Reminder):
+        return cls(
+            id=reminder.id,
+            title=reminder.title,
+            description=reminder.description,
+            color_code=Reminder.convert_from_int_to_hex(reminder.color_code),
+            is_active=reminder.is_active,
+            is_periodic=reminder.is_periodic,
+            created_at=reminder.created_at,
+            last_edited_at=reminder.last_edited_at,
+            triggered_at=reminder.triggered_at,
+            trigger_period=reminder.trigger_period
+        )

--- a/src/DTO/reminder_created_DTO.py
+++ b/src/DTO/reminder_created_DTO.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ReminderCreatedDTO:
+    """
+    Stores information about newly created reminder.
+    """
+    is_created: bool
+    event_id: int

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,16 @@
+from aiohttp import web
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.views import init_application_routes
+
+
+def main(
+    host: str, port: int,
+    session_factory: async_sessionmaker[AsyncSession]
+):
+    app: web.Application = web.Application()
+    app["session_maker"] = session_factory
+    session_factory()
+    init_application_routes(app)
+
+    web.run_app(app, host=host, port=port)

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,0 +1,21 @@
+import asyncio
+import tomllib
+
+from src import main
+from src.models import initialize_connector
+from src.models.initialize_connector import create_engine, initialize_session_maker
+
+with open("config.toml", "rb") as cfg:
+    config = tomllib.load(cfg)["RemindMe"]
+    host = config["host"]
+    port = config["port"]
+    debug_run = config["debug"]
+    engine_conn_str = config["engine_connection"]
+
+    if debug_run:
+        engine = create_engine(engine_conn_str)
+        asyncio.run(initialize_connector.reinitialize_db(engine))
+        del engine
+
+    session_factory = initialize_session_maker(engine_conn_str)
+    asyncio.run(main(host, port, session_factory))

--- a/src/controllers/create_reminder.py
+++ b/src/controllers/create_reminder.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+
+from sqlalchemy.exc import (
+    DataError, StatementError,
+    ProgrammingError, IntegrityError
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.DTO.reminder_created_DTO import ReminderCreatedDTO
+from src.models.reminder import Reminder
+from src.models.user import User
+
+
+async def create_reminder(
+    user_token: str, session: AsyncSession, /,
+    title: str, description: str, color_code: str,
+    triggered_at: datetime, is_periodic: bool, trigger_period: int
+) -> ReminderCreatedDTO:
+    user: User = await User.get_user_by_access_token(
+        user_token, session
+    )
+
+    try:
+        reminder: Reminder | None = await Reminder.create_new_reminder(
+            user.id, title, description, color_code, triggered_at,
+            is_periodic, trigger_period, session
+        )
+
+        if reminder is None:
+            raise ValueError("Reminder was not created due to some error")
+
+    except (
+        IntegrityError, DataError, StatementError,
+        ProgrammingError, ValueError
+    ) as e:
+        raise ValueError("Incorrect data received") from e
+
+    return ReminderCreatedDTO(True, reminder.id)

--- a/src/controllers/deactivate_reminder.py
+++ b/src/controllers/deactivate_reminder.py
@@ -1,0 +1,48 @@
+from aiohttp import web
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.reminder import Reminder
+from src.models.user import User
+from .exceptions import ObjectNotFound
+
+
+async def deactivate_specific_reminder(
+    user_token: str, reminder_id: int, session: AsyncSession
+) -> dict[str, int | bool]:
+    """
+    Deactivates specified reminder by its id if it is created by user who
+    makes request, resulting in being not listed in future when requesting
+    all reminders.
+
+    :param user_token: users token of someone who wants to deactivate reminder.
+    :param reminder_id: id of reminder to deactivate.
+    :param session: SQLAlchemy session.
+    :return: dict with prepared view that can be serialized into response.
+
+    :raise ObjectNotFound: if reminder was not found in database relating
+    to user.
+    :raise InvalidCredentials: if users token is not in database.
+    :raise HTTPInternalServerError: if objects were found, but
+    deactivation failed.
+    """
+    user: User = await User.get_user_by_access_token(
+        user_token, session
+    )
+
+    reminder: Reminder | None = await Reminder.get_reminder_by_id(
+        user.id, reminder_id, session
+    )
+
+    if reminder is None:
+        raise ObjectNotFound(
+            f"Reminder with id {reminder_id} was not found "
+            f"for user with id {user.id}"
+        )
+
+    event_id: int = reminder.id
+    is_deactivated: bool = await reminder.deactivate_reminder(session)
+    if not is_deactivated:
+        # Unknown reason, need to check logs
+        raise web.HTTPInternalServerError()
+
+    return {"deleted_event_id": event_id, "has_been_deactivated": is_deactivated}

--- a/src/controllers/exceptions.py
+++ b/src/controllers/exceptions.py
@@ -1,0 +1,4 @@
+class ObjectNotFound(Exception):
+    """
+    Raised when object was mandatory but was not found
+    """

--- a/src/controllers/fetch_all_reminders.py
+++ b/src/controllers/fetch_all_reminders.py
@@ -1,0 +1,19 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from src.DTO.reminder_DTO import ReminderDTO
+from src.models.reminder import Reminder
+from src.models.user import User
+
+
+async def fetch_all_reminders(
+    user_token: str, session: AsyncSession
+) -> list[ReminderDTO]:
+    user: User = await User.get_user_by_access_token(
+        user_token, session
+    )
+
+    reminders: tuple[
+        Reminder, ...
+    ] = await Reminder.get_active_reminders_of_user(
+        user.id, session
+    )
+    return [ReminderDTO.from_reminder(reminder) for reminder in reminders]

--- a/src/controllers/fetch_reminder.py
+++ b/src/controllers/fetch_reminder.py
@@ -1,0 +1,39 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.DTO.reminder_DTO import ReminderDTO
+from src.models.reminder import Reminder
+from src.models.user import User
+from .exceptions import ObjectNotFound
+
+
+async def fetch_specific_reminder(
+    user_token: str, reminder_id: int, session: AsyncSession
+) -> ReminderDTO:
+    """
+    Fetches specified reminder by its id if it's related to user
+    whose token was provided.
+
+    :param user_token: users token of someone who wants to fetch reminder.
+    :param reminder_id: id of reminder to fetch.
+    :param session: SQLAlchemy session.
+    :return: instance of serializable DTO representing the reminder.
+
+    :raise ObjectNotFound: if reminder was not found in database relating
+    to user.
+    :raise InvalidCredentials: if users token is not in database.
+    """
+    user: User = await User.get_user_by_access_token(
+        user_token, session
+    )
+
+    reminder: Reminder | None = await Reminder.get_reminder_by_id(
+        user.id, reminder_id, session
+    )
+
+    if reminder is None:
+        raise ObjectNotFound(
+            f"Reminder with id {reminder_id} was not found "
+            f"for user with id {user.id}"
+        )
+
+    return ReminderDTO.from_reminder(reminder)

--- a/src/controllers/update_reminder.py
+++ b/src/controllers/update_reminder.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.controllers.exceptions import ObjectNotFound
+from src.models.reminder import Reminder
+from src.models.user import User
+
+
+async def update_specific_reminder(
+    user_token: str, reminder_id: int, session: AsyncSession, *,
+    title: str | None = None,
+    description: str | None = None,
+    color_code: str | None = None,
+    triggered_at: datetime | None = None,
+    is_periodic: bool = None,
+    trigger_period: int | None = None
+) -> list[str]:
+    """
+    Updates fields of specific event that is created by user,
+    whose token is provided in request.
+
+    :param user_token: users token of someone who wants to update reminder.
+    :param reminder_id: id of reminder to update.
+    :param session: SQLAlchemy session.
+    :param title: new title.
+    :param description: new description.
+    :param color_code: HEX color code in string format.
+    :param triggered_at: when will event be triggered first time.
+    :param is_periodic: will event be triggered again in some period.
+    :param trigger_period: how many days should pass before
+    event is triggered again.
+    :param _: stores all invalid keys.
+    :return: list of updated fields.
+
+    :raise ProgrammingError: if case one of parameters received
+    invalid data that has wrong type.
+    :raise ValueError: if no fields to update.
+    :raise ObjectNotFound: if reminder was not found in database relating
+    to user.
+    :raise InvalidCredentials: if users token is not in database.
+    """
+    user: User = await User.get_user_by_access_token(
+        user_token, session
+    )
+    reminder: Reminder | None = await Reminder.get_reminder_by_id(
+        user.id, reminder_id, session
+    )
+
+    if reminder is None:
+        raise ObjectNotFound(
+            f"Reminder with id {reminder_id} was not found "
+            f"for user with id {user.id}"
+        )
+
+    fields: dict[str, Any] = {}
+
+    if title is not None:
+        fields["title"] = title
+
+    if description is not None:
+        fields["description"] = description
+
+    if color_code is not None:
+        fields["color_code"] = color_code
+
+    if triggered_at is not None:
+        fields["triggered_at"] = triggered_at
+
+    if trigger_period is not None:
+        fields["trigger_period"] = trigger_period
+
+    if is_periodic is not None:
+        fields["is_periodic"] = is_periodic
+
+    if len(fields) == 0:
+        raise ValueError("Fields not updated")
+
+    return await reminder.update_reminder(session, **fields)

--- a/src/controllers/user_authentication.py
+++ b/src/controllers/user_authentication.py
@@ -1,0 +1,28 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.user import User
+
+
+async def authenticate_user(
+    username: str,
+    password: str,
+    session: AsyncSession
+) -> str:
+    """
+    Authenticates user by checking if provided username
+    is associated with provided password
+    and returns access token as response.
+
+    :param username: users login.
+    :param password: users password in open form.
+    :param session: SQLAlchemy session.
+    :return: access token if user successfully authenticated.
+
+    :raises ValueError: when user is not registered in database.
+    :raises InvalidCredentials: when user did not provide correct password.
+    """
+
+    user = await User.get_user_by_login_and_password(
+        username, password, session
+    )
+    return user.access_token

--- a/src/controllers/user_registration.py
+++ b/src/controllers/user_registration.py
@@ -1,0 +1,17 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.user import User
+
+
+async def register_user(
+    username: str, password: str, session: AsyncSession
+) -> bool:
+    """
+    Registers new user in database.
+
+    :param username: users login.
+    :param password: users password in open form.
+    :param session: SQLAlchemy session.
+    :return: boolean value that confirms registration
+    """
+    return await User.register_user(username, password, session)

--- a/src/models/exceptions.py
+++ b/src/models/exceptions.py
@@ -1,0 +1,4 @@
+class InvalidCredentials(Exception):
+    """
+    Raised when user provided invalid credentials to access data.
+    """

--- a/src/models/initialize_connector.py
+++ b/src/models/initialize_connector.py
@@ -1,0 +1,57 @@
+from sqlalchemy.ext.asyncio import (
+    AsyncAttrs, AsyncSession, AsyncEngine,
+    create_async_engine, async_sessionmaker
+)
+from sqlalchemy.orm import DeclarativeBase
+
+
+def create_engine(connection_url: str) -> AsyncEngine:
+    """
+    Creates db engine.
+
+    :param connection_url: string with initialization parameters for engine.
+    :return: engine instance.
+    """
+    return create_async_engine(connection_url)
+
+
+def create_session_factory(
+    engine: AsyncEngine
+) -> async_sessionmaker[AsyncSession]:
+    """
+    Creates session factory from session.
+
+    :param engine: provided engine.
+    :return: async_sessionmaker factory.
+    """
+    return async_sessionmaker(engine)
+
+
+def initialize_session_maker(
+    connection_url: str
+) -> async_sessionmaker[AsyncSession]:
+    """
+    Combines engine creation and session factory creation.
+
+    :param connection_url: string with initialization parameters for engine.
+    :return: async_sessionmaker factory.
+    """
+    return create_session_factory(
+        create_engine(connection_url)
+    )
+
+
+async def reinitialize_db(engine: AsyncEngine) -> None:
+    user_module = __import__("src.models.user")
+    reminder_module = __import__("src.models.reminder")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(OrmBase.metadata.drop_all)
+        await conn.run_sync(OrmBase.metadata.create_all)
+
+
+class OrmBase(AsyncAttrs, DeclarativeBase):
+    """
+    Base class for ORM models.
+    """
+    pass

--- a/src/models/reminder.py
+++ b/src/models/reminder.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import (
+    and_, select, func,
+    String, CheckConstraint, ForeignKey, DateTime
+)
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .initialize_connector import OrmBase
+
+
+class Reminder(OrmBase):
+    """
+    Class that represents reminder in database used by ORM.
+    """
+
+    __tablename__ = "reminder"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    authored_by_user_id: Mapped[int] = mapped_column(
+        ForeignKey("user.id")
+    )
+    # Notification title
+    title: Mapped[str] = mapped_column(
+        String(65),
+        CheckConstraint("length(title) > 0")
+    )
+    # Notification description
+    description: Mapped[str] = mapped_column(
+        String(240)
+    )
+    # Color code for reminder in app
+    color_code: Mapped[int] = mapped_column(
+        CheckConstraint(
+            "color_code BETWEEN 0 AND (256*256*256 - 1)"
+        )
+    )
+    # Is reminder active and sends notifications
+    is_active: Mapped[bool] = mapped_column(default=True)
+    # Is reminder repeating itself on intervals
+    is_periodic: Mapped[bool]
+    # When reminder was created
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now()
+    )
+    # When was the last edit (used for syncing and overriding old reminders
+    last_edited_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now()
+    )
+    # When will event be first triggered at
+    triggered_at: Mapped[datetime.datetime]
+    # How many days before the event will be triggered again
+    trigger_period: Mapped[int] = mapped_column(
+        CheckConstraint(
+            "trigger_period >= 0"
+        )
+    )
+
+    async def update_reminder(
+        self, session: AsyncSession, **fields
+    ) -> list[str]:
+        """
+        Modifies allowed fields of specific reminder.
+
+        :param session: SQLAlchemy session.
+        :param fields: fields to update. Allowed fields are:
+        title, description, color_code,
+        is_periodic, triggered_at, trigger_period.
+        :return: list of fields names that were modified.
+        """
+
+        MODIFIABLE_FIELDS: frozenset[str] = frozenset({
+            'title', 'description',
+            'color_code', 'is_periodic',
+            'triggered_at', 'trigger_period',
+        })
+
+        fields_to_modify = set(fields.keys()) & MODIFIABLE_FIELDS
+        modified_fields = []
+
+        try:
+            if 'color_code' in fields_to_modify:
+                fields_to_modify.remove('color_code')
+                modified_fields.append('color_code')
+                self.color_code: int = self.convert_from_hex_to_int_color(
+                    fields['color_code']
+                )
+
+            for key in fields_to_modify:
+                # dynamically update all fields
+                setattr(self, key, fields[key])
+                modified_fields.append(key)
+
+            # Try commiting changes to database to check if values are ok
+            await session.commit()
+            return modified_fields
+
+        except IntegrityError:
+            await session.rollback()
+            return []
+
+    async def deactivate_reminder(self, session: AsyncSession) -> bool:
+        try:
+            self.is_active: bool = False
+            await session.commit()
+            return True
+
+        except IntegrityError:
+            await session.rollback()
+            return False
+
+    @classmethod
+    async def create_new_reminder(
+        cls, user_id: int, title: str, description: str,
+        color_code: str, triggered_at: datetime.datetime,
+        is_periodic: bool, trigger_period: int, session: AsyncSession
+    ) -> Reminder | None:
+        reminder = cls(
+            authored_by_user_id=user_id,
+            title=title,
+            description=description,
+            color_code=cls.convert_from_hex_to_int_color(color_code),
+            triggered_at=triggered_at,
+            is_periodic=is_periodic,
+            trigger_period=trigger_period
+        )
+
+        async with session.begin_nested() as tr:
+            session.add(reminder)
+            try:
+                await tr.commit()
+
+            except IntegrityError as e:
+                await tr.rollback()
+                return None
+
+        return reminder
+
+    @classmethod
+    async def get_reminder_by_id(
+        cls, user_id: int, reminder_id: int, session: AsyncSession
+    ) -> Reminder | None:
+        """
+        Fetches reminder by its ID and ID of user who authored reminder.
+
+        :param user_id: user who requests reminder by ID.
+        :param reminder_id: ID of reminder to fetch.
+        :param session: SQLAlchemy session.
+        :return: instance of Reminder or None in case there's
+        no such Reminder for that user.
+        """
+        query = select(cls).where(
+            and_(
+                cls.authored_by_user_id == user_id,
+                cls.id == reminder_id
+            )
+        )
+        result: Reminder | None = (await session.execute(query)).scalar()
+        return result
+
+    @classmethod
+    async def get_active_reminders_of_user(
+        cls, user_id: int, session: AsyncSession
+    ) -> tuple[Reminder, ...]:
+        """
+        Fetches all active reminders that belong to specified user.
+
+        :param user_id: user whose reminders need to be fetched.
+        :param session: SQLAlchemy session.
+        :return: tuple of Reminder objects.
+        """
+        query = select(cls).where(
+            and_(
+                cls.authored_by_user_id == user_id,
+                cls.is_active.is_(True)
+            )
+        )
+
+        return tuple((await session.execute(query)).scalars().all())
+
+    @classmethod
+    async def get_deactivated_reminders_of_user(
+        cls, user_id: int, session: AsyncSession
+    ) -> tuple[Reminder, ...]:
+        """
+        Fetches all deactivated reminders that belong to specified user.
+        :param user_id: user whose reminders need to be fetched.
+        :param session: SQLAlchemy session.
+        :return: tuple of Reminder objects.
+        """
+        query = select(cls).where(
+            and_(
+                cls.authored_by_user_id == user_id,
+                cls.is_active.is_(False)
+            )
+        )
+
+        return tuple((await session.execute(query)).scalars().all())
+
+    @staticmethod
+    def convert_from_hex_to_int_color(hex_color: str) -> int:
+        """
+        Helper method that converts hex string into integer value,
+        and checks boundaries.
+
+        :param hex_color: input string of HEX color representation
+        (RRGGBB format).
+        :return: converted integer value.
+        :raises ValueError: if string is invalid value in base 16
+        or out of possible HEX color range.
+        """
+        if (value := int(hex_color, 16)) not in range(0, 256**3):
+            raise ValueError("Invalid boundaries for HEX color")
+
+        return value
+
+    @staticmethod
+    def convert_from_int_to_hex(color: int) -> str:
+        """
+        Converts int representation of color into HEX string
+        with leading zeros.
+
+        :param color: integer representing the color in RRGGBB format.
+        :return:
+        """
+        return f'{color:x}'.zfill(6).upper()

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import datetime
+import secrets
+from hashlib import pbkdf2_hmac
+
+from sqlalchemy import func, select, DateTime
+from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .exceptions import InvalidCredentials
+from .initialize_connector import OrmBase
+
+
+class User(OrmBase):
+    """
+    Class that represents user in database used by ORM.
+    """
+
+    __tablename__ = "user"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now()
+    )
+    username: Mapped[str] = mapped_column(unique=True, index=True)
+    salt: Mapped[str]
+    password: Mapped[str]
+    access_token: Mapped[str] = mapped_column(unique=True, index=True)
+
+    @classmethod
+    async def register_user(
+        cls, username: str, password: str, session: AsyncSession
+    ) -> bool:
+        """
+        Registers user in database.
+
+        :param username: users name.
+        :param password: users password.
+        :param session: SQLAlchemy session.
+        :return: boolean value representing if use has been saved to database
+        """
+        salt = secrets.token_urlsafe(64)
+        password_hash: str = pbkdf2_hmac(
+            'sha256', password.encode('utf-8'),
+            salt=salt.encode('utf-8'), iterations=10000
+        ).hex()
+        access_token: str = await cls.get_unique_access_token(session)
+
+        session.add(
+            cls(
+                username=username,
+                password=password_hash,
+                salt=salt,
+                access_token=access_token
+            )
+        )
+        try:
+            await session.commit()
+            return True
+
+        except IntegrityError:
+            await session.rollback()
+            return False
+
+    @classmethod
+    async def get_user_by_login_and_password(
+        cls, username: str, password: str, session: AsyncSession
+    ) -> User:
+        """
+        Fetches user object via provided login and plain password,
+        checks if passwords match, and gives back object of user.
+
+        :param username: users login.
+        :param password: users plain password.
+        :param session: SQLAlchemy session.
+        :return: object of class User when password matched one saved in db.
+        :raise InvalidCredentials: when password in db
+        and provided by user are mismatching.
+        :raise ValueError: if user is not registered.
+        """
+        query = select(cls).where(User.username == username)
+        try:
+            result: User = (await session.execute(query)).scalars().one()
+
+            password_hash: str = pbkdf2_hmac(
+                'sha256', password.encode('utf-8'),
+                salt=result.salt.encode('utf-8'), iterations=10000
+            ).hex()
+
+            if result.password == password_hash:
+                return result
+
+            else:
+                raise InvalidCredentials()
+
+        except NoResultFound:
+            raise ValueError("No such user registered")
+
+    @classmethod
+    async def get_user_by_access_token(
+        cls, access_token: str, session: AsyncSession
+    ) -> User:
+        """
+        Gets User object from db by access token.
+
+        :param access_token: users access token.
+        :param session: SQlAlchemy session.
+        :return: object of User class when access_token is in db.
+        :raise InvalidCredentials: if there is no such access token in db.
+        """
+        try:
+            query = select(cls).where(cls.access_token == access_token)
+            result: User = (await session.execute(query)).scalars().one()
+
+            return result
+
+        except NoResultFound:
+            raise InvalidCredentials()
+
+    @staticmethod
+    async def get_unique_access_token(session: AsyncSession) -> str:
+        """
+        Generates unique access token for usage later.
+
+        :param session: SQLAlchemy session.
+        :return: not registered token.
+        """
+        access_token: str = secrets.token_urlsafe(128)
+
+        token_exists_check = select(
+            func.count(User.id)
+        ).where(
+            User.access_token == access_token
+        )
+        while await session.scalar(token_exists_check):
+            access_token = secrets.token_urlsafe(128)
+
+        return access_token

--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -1,0 +1,59 @@
+from aiohttp import web
+
+from .active_reminders import handle_fetching_active_reminders
+from .authenticate_user import handle_authentication
+from .create_new_reminder import handle_creating_reminder
+from .logout_from_account import handle_logout
+from .register_user import handle_registration
+from .reminder_specific_actions import (
+    handle_fetching_specific_reminder,
+    handle_deactivating_specific_reminder,
+    handle_updating_specific_reminder
+)
+
+
+def init_application_routes(app: web.Application) -> None:
+    app.add_routes(
+        [
+            web.route(
+                "post",
+                "/users/register",
+                handle_registration
+            ),
+            web.route(
+                "post",
+                "/users/login",
+                handle_authentication
+            ),
+            web.route(
+                "post",
+                "/users/logout",
+                handle_logout
+            ),
+            web.route(
+                "get",
+                "/reminders/",
+                handle_fetching_active_reminders
+            ),
+            web.route(
+                "post",
+                "/reminders/",
+                handle_creating_reminder
+            ),
+            web.route(
+                "get",
+                r"/reminders/{reminderId:\d+}",
+                handle_fetching_specific_reminder
+            ),
+            web.route(
+                "delete",
+                r"/reminders/{reminderId:\d+}",
+                handle_deactivating_specific_reminder
+            ),
+            web.route(
+                "patch",
+                r"/reminders/{reminderId:\d+}",
+                handle_updating_specific_reminder
+            ),
+        ]
+    )

--- a/src/views/active_reminders.py
+++ b/src/views/active_reminders.py
@@ -1,0 +1,36 @@
+import orjson
+from aiohttp import web
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.DTO.reminder_DTO import ReminderDTO
+from src.controllers.fetch_all_reminders import fetch_all_reminders
+from src.models.exceptions import InvalidCredentials
+from .inject_session import inject_session
+
+
+# get /reminders/
+@inject_session
+async def handle_fetching_active_reminders(
+    request: web.Request, session: AsyncSession
+) -> web.Response:
+    """
+    Fetches all users active reminders.
+
+    :param request: http request.
+    :param session: SQLAlchemy session.
+    :return: web response with all active reminders or error message.
+    """
+
+    try:
+        reminders: list[ReminderDTO] = await fetch_all_reminders(
+            request.cookies["UserToken"],
+            session
+        )
+
+        return web.Response(body=orjson.dumps(reminders))
+
+    except (InvalidCredentials, KeyError):
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )

--- a/src/views/authenticate_user.py
+++ b/src/views/authenticate_user.py
@@ -1,0 +1,49 @@
+import orjson
+from aiohttp import web
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.controllers.user_authentication import authenticate_user
+from .inject_session import inject_session
+from src.models.exceptions import InvalidCredentials
+
+
+# post /users/login
+@inject_session
+async def handle_authentication(
+    request: web.Request, session: AsyncSession
+) -> web.Response:
+    """
+    Authenticates user by provided credentials and responds with set-cookie,
+    providing access token for future API usage.
+
+    :param request: http request.
+    :param session: SQLAlchemy session.
+    :return: web response with set-cookie header or error message.
+    """
+    try:
+        request_body: dict = await request.json(loads=orjson.loads)
+        username: str = str(request_body["username"]).strip()
+        password: str = str(request_body["password"]).strip()
+
+    except (orjson.JSONDecodeError, KeyError, AttributeError):
+        return web.Response(status=400, body=orjson.dumps(
+            {"reason": "Invalid body format or missing fields from json"}
+        ))
+
+    try:
+        access_token = await authenticate_user(username, password, session)
+
+    except ValueError:
+        return web.Response(status=404, body=orjson.dumps(
+            {"reason": "User with provided login does not exists"}
+        ))
+
+    except InvalidCredentials:
+        return web.Response(status=401, body=orjson.dumps(
+            {"reason": "Invalid password provided"}
+        ))
+
+    response = web.Response()
+    response.set_cookie("UserToken", access_token, httponly=True)
+
+    return response

--- a/src/views/create_new_reminder.py
+++ b/src/views/create_new_reminder.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from typing import Any
+
+import orjson
+from aiohttp import web
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.DTO.reminder_created_DTO import ReminderCreatedDTO
+from src.controllers.create_reminder import create_reminder
+from src.models.exceptions import InvalidCredentials
+from .inject_session import inject_session
+
+
+# post /reminders/
+@inject_session
+async def handle_creating_reminder(
+    request: web.Request, session: AsyncSession
+) -> web.Response:
+    """
+
+    :param request:
+    :param session:
+    :return:
+    """
+
+    try:
+        user_token: str = request.cookies["UserToken"]
+
+    except KeyError:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )
+
+    try:
+        body: dict[str, Any] = await request.json()
+        new_event_data: dict[str, Any] = {
+            "title": body["title"].strip(),
+            "description": body["description"].strip(),
+            "color_code": body["color_code"].strip(),
+            "triggered_at": datetime.fromisoformat(body["triggered_at"]),
+            "is_periodic": body["is_periodic"],
+            "trigger_period": int(body["trigger_period"])
+        }
+
+        if not isinstance(new_event_data["is_periodic"], bool):
+            raise TypeError("Invalid type for is_periodic variable")
+
+        result: ReminderCreatedDTO = await create_reminder(
+            user_token, session, **new_event_data
+        )
+
+        return web.Response(
+            body=orjson.dumps(result)
+        )
+
+    except (KeyError, TypeError, ValueError, AttributeError):
+        return web.Response(
+            status=400,
+            reason="Invalid request body"
+        )
+
+    except InvalidCredentials:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )

--- a/src/views/inject_session.py
+++ b/src/views/inject_session.py
@@ -1,0 +1,28 @@
+from functools import wraps
+from typing import Callable, Awaitable
+
+from aiohttp import web
+from aiohttp.web_request import Request
+from aiohttp.web_response import Response
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+def inject_session(
+    handler: Callable[[web.Request, AsyncSession], Awaitable[web.Response]]
+) -> Callable[[Request], Awaitable[Response]]:
+    """
+    Decorator that injects AsyncSession into aiohttp handler.
+
+    :param handler: request handler that needs async session.
+    :return: decorated function.
+    """
+    @wraps(handler)
+    async def handle_session(request: web.Request):
+        session_maker: async_sessionmaker[
+            AsyncSession
+        ] = request.app["session_maker"]
+        async with session_maker() as session:
+            async with session.begin():
+                resp = await handler(request, session)
+        return resp
+    return handle_session

--- a/src/views/logout_from_account.py
+++ b/src/views/logout_from_account.py
@@ -1,0 +1,19 @@
+from aiohttp import web
+
+
+# post /users/logout
+async def handle_logout(request: web.Request) -> web.Response:
+    """
+    Removes cookie on client side with authentication token if it's present.
+
+    :param request: http request.
+    :return: web response with header that removes cookie.
+    """
+
+    if request.cookies.get("UserToken"):
+        response: web.Response = web.Response()
+        response.del_cookie("UserToken")
+        return response
+
+    else:
+        return web.Response(reason="Not authorized", status=401)

--- a/src/views/register_user.py
+++ b/src/views/register_user.py
@@ -1,0 +1,89 @@
+import re
+
+import orjson
+from aiohttp import web
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.controllers.user_registration import register_user
+from .inject_session import inject_session
+
+USERNAME_REGEX = re.compile(r"^[A-z0-9_]{8,}")
+USER_PASSWORD_REGEX = re.compile(r"^[A-z0-9_+\-=]{8,}")
+
+
+# post /users/register
+@inject_session
+async def handle_registration(
+    request: web.Request, session: AsyncSession
+) -> web.Response:
+    """
+    Registers user in system.
+
+    :param request: http request.
+    :param session: SQLAlchemy session.
+    :return: web response with reason or indication.
+    """
+    try:
+        request_body: dict = await request.json(loads=orjson.loads)
+        username: str = str(request_body["username"]).strip()
+
+        if USERNAME_REGEX.fullmatch(username) is None:
+            return web.Response(
+                status=400,
+                body=orjson.dumps(
+                    {
+                        "reason":
+                            "Incorrect incoming body, expected ascii "
+                            "sequence of 8 symbols for username"
+                    }
+                )
+            )
+
+        password: str = str(request_body["password"]).strip()
+
+        if USER_PASSWORD_REGEX.fullmatch(password) is None:
+            return web.Response(
+                status=400,
+                body=orjson.dumps(
+                    {
+                        "reason":
+                            "Incorrect incoming body, expected at least "
+                            "8 ascii characters as password"
+                    }
+                )
+            )
+
+        successful_registration = await register_user(
+            username, password, session
+        )
+
+    except (orjson.JSONDecodeError, KeyError, AttributeError):
+        return web.Response(
+            status=400,
+            body=orjson.dumps(
+                {
+                    "reason": "Incorrect incoming body, expected json"
+                }
+            )
+        )
+
+    if successful_registration:
+        return web.Response(
+            body=orjson.dumps(
+                {
+                    "registered": successful_registration
+                }
+            )
+        )
+
+    else:
+        return web.Response(
+            status=409,
+            body=orjson.dumps(
+                {
+                    "reason": "User is already registered in database "
+                              "with such login",
+                    "registered": successful_registration
+                }
+            )
+        )

--- a/src/views/reminder_specific_actions.py
+++ b/src/views/reminder_specific_actions.py
@@ -1,0 +1,193 @@
+from datetime import datetime
+from typing import Any
+
+import orjson
+from aiohttp import web
+from sqlalchemy.exc import DataError, StatementError, ProgrammingError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.DTO.reminder_DTO import ReminderDTO
+from src.controllers.deactivate_reminder import deactivate_specific_reminder
+from src.controllers.exceptions import ObjectNotFound
+from src.controllers.fetch_reminder import fetch_specific_reminder
+from src.controllers.update_reminder import update_specific_reminder
+from src.models.exceptions import InvalidCredentials
+from .inject_session import inject_session
+
+
+# get /reminders/{reminderId:\d+}
+@inject_session
+async def handle_fetching_specific_reminder(
+    request: web.Request, session: AsyncSession
+) -> web.Response:
+    """
+    Fetches specified users reminder.
+
+    :param request: http request.
+    :param session: SQLAlchemy session.
+    :return: web response with reminder or error message.
+    """
+
+    try:
+        user_token: str = request.cookies["UserToken"]
+
+    except KeyError:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )
+
+    try:
+        # Fetching reminder by url variable
+        reminder: ReminderDTO = await fetch_specific_reminder(
+            user_token, int(request.match_info["reminderId"]), session
+        )
+
+        return web.Response(
+            body=orjson.dumps(reminder)
+        )
+
+    except (DataError, ValueError, KeyError):
+        return web.Response(
+            status=400,
+            reason="Provided parameter in request is invalid"
+        )
+
+    except InvalidCredentials:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )
+
+    except (AttributeError, ObjectNotFound):
+        return web.Response(
+            status=404,
+            body={
+                "reason":
+                    "Provided ID in URL parameter is not found for that user"
+            }
+        )
+
+
+# delete /reminders/{reminderId:\d+}
+@inject_session
+async def handle_deactivating_specific_reminder(
+    request: web.Request, session: AsyncSession
+) -> web.Response:
+    """
+    Deletes specified users reminder.
+
+    :param request: http request.
+    :param session: SQLAlchemy session.
+    :return: web response with confirmation that
+    reminder is deleted or error message.
+    """
+
+    try:
+        user_token: str = request.cookies["UserToken"]
+
+    except KeyError:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )
+
+    try:
+        body: dict[str, int | bool] = await deactivate_specific_reminder(
+            user_token, int(request.match_info["reminderId"]), session
+        )
+
+        return web.Response(
+            body=orjson.dumps(body)
+        )
+
+    except (DataError, ValueError, KeyError):
+        return web.Response(
+            status=400,
+            reason="Provided parameters in request are invalid"
+        )
+
+    except InvalidCredentials:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )
+
+    except (AttributeError, ObjectNotFound):
+        return web.Response(
+            status=404,
+            body={
+                "reason":
+                    "Provided ID in URL parameter is not found for that user"
+            }
+        )
+
+
+# patch /reminders/{reminderId:\d+}
+@inject_session
+async def handle_updating_specific_reminder(
+    request: web.Request, session: AsyncSession
+) -> web.Response:
+    """
+    Fetches specified users reminder.
+
+    :param request: http request.
+    :param session: SQLAlchemy session.
+    :return: web response with reminder or error message.
+    """
+
+    try:
+        user_token: str = request.cookies["UserToken"]
+
+    except KeyError:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )
+
+    try:
+        body: dict[str, Any] = await request.json()
+
+        if "triggered_at" in body:
+            try:
+                body["triggered_at"] = datetime.fromisoformat(
+                    body["triggered_at"]
+                )
+
+            except TypeError as e:
+                raise ValueError(
+                    f"Invalid triggered_at field type "
+                    f"(got {type(body['triggered_at'])}"
+                ) from e
+
+        updated_fields: list[str] = await update_specific_reminder(
+            user_token, int(request.match_info["reminderId"]), session,
+            **body
+        )
+
+        return web.Response(
+            body=orjson.dumps(updated_fields)
+        )
+
+    except (DataError, StatementError, ProgrammingError, AttributeError, TypeError, ValueError):
+        return web.Response(
+            status=400,
+            reason="Invalid request body or URL parameter"
+        )
+
+    except InvalidCredentials:
+        return web.Response(
+            status=401,
+            reason="Client is not authorized"
+        )
+
+    except (KeyError, ObjectNotFound) as e:
+        return web.Response(
+            status=404,
+            body=orjson.dumps(
+                {
+                    "reason":
+                        "Provided ID in URL parameter is not found for that user"
+                }
+            )
+        )


### PR DESCRIPTION
* Add methods for user registration and authorization database queries

* Add docstrings

* Fix typing errors Fix missing response in user registration handler
Add registration controller implementation

* Add OpenAPI description of future API

* Specify /reminders/{reminderId} requiring at least one property specified

* Change regex for matching username and password Use regex in server side validation for logins and password

* Register handler for /users/registration endpoint Fix typehint on inject_session decorator

* Remove requirements for login and password on /users/login route since it only needs to check legitimacy of login request

* Fix possibility to crash server with unchecked values

* Add message about incorrect request body

* Handle error in case json doesn't have fields

* Fix file formatting

* Implement user authentication

* Include timezone into database Fix long string of parameters

* Update OpenAPI spec with new limitations and errors

* Add Reminder model Add ReminderDTO class for converting Reminder model into JSON

* Fix PEP-8 style Fix direct test of values on SQLAlchemy objects against bool values

* Add route for logging out of account

* Implement logging out of account

* Update reminders fetching routes to both be consistent with data schema

* Add description of what handlers path is

* Implement active reminders fetching Add class method to ReminderDTO class that creates an instance from Reminder ORM object

* Change imports ordering and make imports absolute Register routes in router

* Specify error for cases when URL parameter is invalid

* Use controller to remove models access from view layer

* Fix mistype in one of description

* Add additional constraints to title and description of reminders

* Change body in response to reason for error path

* Fix formatting to fit PEP-8 Change order of imports to be alphabetic in active_reminders.py

* Fix formatting to fit PEP-8 Add routes registrations
Add implementation for view and controller for working with requesting reminders Add implementations for views and controllers for working with specific reminders

* Implement creation of new reminders

* Rename handler to correct name

* Shorten api_spec.yaml using reference to schema

* Remove minimal length requirement for event description

* Remove minimal length requirement for event description from code

* Add missing dependency for postgresql connector Add missing field to be updated in Reminder object Fix HTTP error 500 on one of cases inside PATCH /reminders/{reminderId} route Fix incorrect error message inside PATCH /reminders/{reminderId} route Fix being unable to create new table reminder in postgresql Add function to help reinitializing database for test purposes Rename one field of response in DELETE /reminders/{reminderId} route to better match action Add missing error handling in route POST /reminders/ Add example config to root directory
Add code to start application when ran as a main module Edit README.md